### PR TITLE
adding rbc_joint

### DIFF
--- a/bin/fit_rbc_1_joint.jl
+++ b/bin/fit_rbc_1_joint.jl
@@ -1,0 +1,3 @@
+using HMCExamples
+
+HMCExamples.main_rbc_1_joint()

--- a/src/HMCExamples.jl
+++ b/src/HMCExamples.jl
@@ -16,5 +16,7 @@ include("experiment_results.jl")
 # Specific Models and CLI drivers
 include("turing_models.jl")
 include("estimate_rbc_1_kalman.jl")
+include("estimate_rbc_1_joint.jl")
+
 
 end #module

--- a/src/estimate_rbc_1_joint.jl
+++ b/src/estimate_rbc_1_joint.jl
@@ -1,0 +1,104 @@
+# Entry for script
+function main_rbc_1_joint(args=ARGS)
+    d = parse_commandline_rbc_1_joint(args)
+    return estimate_rbc_1_joint((; d...)) # to named tuple
+end
+
+function estimate_rbc_1_joint(d)
+    # Or move these into main package when loading?
+    Turing.setadbackend(:zygote)
+    HMCExamples.set_BLAS_threads()
+    use_tensorboard = true # could add toggle later
+
+    # load data relative to the current path
+    data_path = joinpath(pkgdir(HMCExamples), d.data_path)
+    df = Matrix(DataFrame(CSV.File(data_path)))
+    z = [df[i, :] for i in 1:size(df, 1)]
+    ϵ0 = Matrix(DataFrame(CSV.File(joinpath(pkgdir(HMCExamples), "data/epsilons_burnin_rbc_1.csv");header=false)))
+    # Create the perturbation and the turing models
+    m = FirstOrderPerturbationModel(rbc_1)
+    turing_model = rbc_joint(
+        z, m, d.p_f, d.alpha_prior, d.beta_prior, d.rho_prior, allocate_cache(m)
+    )
+
+    # Sampler
+    name = "rbc-joint-s$(d.num_samples)-seed$(d.seed)"
+    include_vars = ["α", "β_draw", "ρ"]  # variables to log
+    callback = TensorBoardCallback(d.results_path; name, include=include_vars)
+    num_adapts = convert(Int64, floor(d.num_samples * d.adapts_burnin_prop))
+
+    Random.seed!(d.seed)
+    @info "Generating $(d.num_samples) samples with $(num_adapts) adapts"
+    alg = NUTS(num_adapts, d.target_acceptance_rate)
+
+    chain = sample(
+        turing_model,
+        NUTS(num_adapts, d.target_acceptance_rate; d.max_depth),
+        d.num_samples;
+        init_params=[d.p; ϵ0],
+        progress=true,
+        save_state=true,
+        callback,
+    )
+
+    # Calculate and save results into the logdir
+    calculate_experiment_results(chain, callback.logger, include_vars, d.full_results)
+    
+    # Store parameters in log directory
+    parameter_save_path = joinpath(callback.logger.logdir, "parameters.json")
+
+    @info "Storing Parameters at $(parameter_save_path) "
+    open(parameter_save_path, "w") do f
+        write(f, JSON.json(d))
+    end
+end
+
+function parse_commandline_rbc_1_joint(args)
+    s = ArgParseSettings(; fromfile_prefix_chars=['@'])
+
+    # See the appropriate _defaults.txt file for the default vvalues.
+    @add_arg_table! s begin
+        "--data_path"
+        help = "relative path to data from the root of the package"
+        arg_type = String
+        "--p"
+        help = "Initialization of parameters"
+        arg_type = Vector{Float64}
+        "--p_f"
+        help = "Value of fixed parameters"
+        arg_type = Vector{Float64}
+        "--alpha_prior"
+        help = "Parameters for the prior"
+        arg_type = Vector{Float64}
+        "--beta_prior"
+        help = "Parameters for the prior"
+        arg_type = Vector{Float64}
+        "--rho_prior"
+        help = "Parameters for the prior"
+        arg_type = Vector{Float64}
+        "--num_samples"
+        help = "samples to draw in chain"
+        arg_type = Int64
+        "--adapts_burnin_prop"
+        help = "Proportion of Adaptations burned in"
+        arg_type = Float64
+        "--target_acceptance_rate"
+        help = "Target acceptance rate for dual averaging for NUTS"
+        arg_type = Float64
+        "--max_depth"
+        help = "Maximum depth for NUTS"
+        arg_type = Int64
+        "--seed"
+        help = "Random number seed"
+        arg_type = Int64
+        "--results_path"
+        arg_type = String
+        help = "Location to store results and logs"
+        "--full_results"
+        arg_type = Bool
+        help = "Save the complete set of figures and results for the chain"
+    end
+
+    args_with_default = vcat("@$(pkgdir(HMCExamples))/src/rbc_1_kalman_defaults.txt", args)
+    return parse_args(args_with_default, s; as_symbols=true)
+end

--- a/src/estimate_rbc_1_joint.jl
+++ b/src/estimate_rbc_1_joint.jl
@@ -99,6 +99,6 @@ function parse_commandline_rbc_1_joint(args)
         help = "Save the complete set of figures and results for the chain"
     end
 
-    args_with_default = vcat("@$(pkgdir(HMCExamples))/src/rbc_1_kalman_defaults.txt", args)
+    args_with_default = vcat("@$(pkgdir(HMCExamples))/src/rbc_1_joint_defaults.txt", args)
     return parse_args(args_with_default, s; as_symbols=true)
 end

--- a/src/rbc_1_joint_defaults.txt
+++ b/src/rbc_1_joint_defaults.txt
@@ -1,0 +1,13 @@
+--data_path=data/rbc_1.csv
+--p=[0.2981, 0.1891, 0.9002]
+--p_f=[0.025, 0.01, 0.003162277]
+--alpha_prior=[0.3, 0.025, 0.2, 0.5]
+--beta_prior=[6.25, 0.04]
+--rho_prior=[2.625, 2.625]
+--num_samples=10000
+--adapts_burnin_prop=0.1
+--target_acceptance_rate=0.65
+--max_depth=5
+--seed=0
+--results_path=.results/run
+--full_results=true

--- a/src/turing_models.jl
+++ b/src/turing_models.jl
@@ -13,3 +13,21 @@
         Turing.@addlogprob! solve(sol, sol.x_ergodic, (0, length(z)); observables = z).logpdf
     end
     
+
+    @model function rbc_joint(z, m, p_f, α_prior, β_prior, ρ_prior, cache, x0 = zeros(m.n_x))
+        α ~ truncated(Normal(α_prior[1], α_prior[2]), α_prior[3], α_prior[4])
+        β_draw ~ Gamma(β_prior[1], β_prior[2])
+        ρ ~ Beta(ρ_prior[1], ρ_prior[2])
+        β = 1 / (β_draw / 100 + 1)
+        p = [α, β, ρ]
+        T = length(z)
+        ϵ_draw ~ MvNormal(m.n_ϵ * T, 1.0)
+        ϵ = map(i -> ϵ_draw[((i - 1) * m.n_ϵ + 1):(i * m.n_ϵ)], 1:T)
+        sol = generate_perturbation(m, p; p_f, cache)
+        if !(sol.retcode == :Success)
+            Turing.@addlogprob! -Inf
+            return
+        end
+        Turing.@addlogprob! solve(sol, x0, (0, T); noise = ϵ, observables = z).logpdf
+    end
+    


### PR DESCRIPTION
The pull request add rbc_joint estimation:

- define code for the the rbc joint estimation, using ```https://github.com/jlperla/FVGQ20Estimation.jl/blob/master/figures/rbc_1_joint.jl```, default $\epsilon0$ from the ```data/epsilons_burnin_rbc_1.csv```, rest of the default params from ```rbc_1_kalman_defaults.txt"
- use function ```fir_rbc_1_joint``` for the command line execution
- add the test for rbc_joint similar to the one for the ```rbc_kalman```   