### PR TITLE
Add multichain-sampling

### DIFF
--- a/src/FVGQ_1_joint_defaults.txt
+++ b/src/FVGQ_1_joint_defaults.txt
@@ -32,3 +32,4 @@
 --print_level=3
 --epsilon_BK=1e-6
 --use_solution_cache=false
+--num_chains=4

--- a/src/FVGQ_1_kalman_defaults.txt
+++ b/src/FVGQ_1_kalman_defaults.txt
@@ -32,3 +32,4 @@
 --print_level=3
 --epsilon_BK=1e-6
 --use_solution_cache=false
+--num_chains=4

--- a/src/FVGQ_2_joint_defaults.txt
+++ b/src/FVGQ_2_joint_defaults.txt
@@ -32,3 +32,4 @@
 --print_level=3
 --epsilon_BK=1e-6
 --use_solution_cache=false
+--num_chains=4

--- a/src/estimate_FVGQ_1_joint.jl
+++ b/src/estimate_FVGQ_1_joint.jl
@@ -64,13 +64,15 @@ function estimate_FVGQ_1_joint(d)
     num_adapts = convert(Int64, floor(d.num_samples * d.adapts_burnin_prop))
 
     Random.seed!(d.seed)
-    @info "Generating $(d.num_samples) samples with $(num_adapts) adapts"
+    @info "Generating $(d.num_samples) samples with $(num_adapts) adapts across $(d.num_chains) chains"
     alg = NUTS(num_adapts, d.target_acceptance_rate)
 
     chain = sample(
         turing_model,
         NUTS(num_adapts, d.target_acceptance_rate; d.max_depth),
-        d.num_samples;
+        MCMCThreads(),
+        d.num_samples,
+        d.num_chains;
         init_params=[d.p,ϵ0],
         progress=true,
         save_state=true,
@@ -179,6 +181,9 @@ function parse_commandline_FVGQ_1_joint(args)
         arg_type = Vector{Float64}
         "--num_samples"
         help = "samples to draw in chain"
+        arg_type = Int64
+        "--num_chains"
+        help = "number of chains to sample"
         arg_type = Int64
         "--adapts_burnin_prop"
         help = "Proportion of Adaptations burned in"

--- a/src/estimate_FVGQ_1_kalman.jl
+++ b/src/estimate_FVGQ_1_kalman.jl
@@ -60,13 +60,15 @@ function estimate_FVGQ_1_kalman(d)
     num_adapts = convert(Int64, floor(d.num_samples * d.adapts_burnin_prop))
 
     Random.seed!(d.seed)
-    @info "Generating $(d.num_samples) samples with $(num_adapts) adapts"
+    @info "Generating $(d.num_samples) samples with $(num_adapts) adapts across $(d.num_chains) chains"
     alg = NUTS(num_adapts, d.target_acceptance_rate)
 
     chain = sample(
         turing_model,
         NUTS(num_adapts, d.target_acceptance_rate; d.max_depth),
-        d.num_samples;
+        MCMCThreads(),
+        d.num_samples,
+        d.num_chains;
         init_params=d.p,
         progress=true,
         save_state=true,
@@ -175,6 +177,9 @@ function parse_commandline_FVGQ_1_kalman(args)
         arg_type = Vector{Float64}
         "--num_samples"
         help = "samples to draw in chain"
+        arg_type = Int64
+        "--num_chains"
+        help = "number of chains to sample"
         arg_type = Int64
         "--adapts_burnin_prop"
         help = "Proportion of Adaptations burned in"

--- a/src/estimate_FVGQ_2_joint.jl
+++ b/src/estimate_FVGQ_2_joint.jl
@@ -65,14 +65,16 @@ function estimate_FVGQ_2_joint(d)
     num_adapts = convert(Int64, floor(d.num_samples * d.adapts_burnin_prop))
 
     Random.seed!(d.seed)
-    @info "Generating $(d.num_samples) samples with $(num_adapts) adapts"
+    @info "Generating $(d.num_samples) samples with $(num_adapts) adapts across $(d.num_chains) chains"
     alg = NUTS(num_adapts, d.target_acceptance_rate)
 
     chain = sample(
         turing_model,
         NUTS(num_adapts, d.target_acceptance_rate; d.max_depth),
-        d.num_samples;
-        init_params=[d.p, ϵ0],
+        MCMCThreads(),
+        d.num_samples,
+        d.num_chains;
+        init_params=[d.p,ϵ0],
         progress=true,
         save_state=true,
         callback,
@@ -180,6 +182,9 @@ function parse_commandline_FVGQ_2_joint(args)
         arg_type = Vector{Float64}
         "--num_samples"
         help = "samples to draw in chain"
+        arg_type = Int64
+        "--num_chains"
+        help = "number of chains to sample"
         arg_type = Int64
         "--adapts_burnin_prop"
         help = "Proportion of Adaptations burned in"

--- a/src/estimate_rbc_1_joint.jl
+++ b/src/estimate_rbc_1_joint.jl
@@ -28,14 +28,16 @@ function estimate_rbc_1_joint(d)
     num_adapts = convert(Int64, floor(d.num_samples * d.adapts_burnin_prop))
 
     Random.seed!(d.seed)
-    @info "Generating $(d.num_samples) samples with $(num_adapts) adapts"
+    @info "Generating $(d.num_samples) samples with $(num_adapts) adapts across $(d.num_chains) chains"
     alg = NUTS(num_adapts, d.target_acceptance_rate)
 
     chain = sample(
         turing_model,
         NUTS(num_adapts, d.target_acceptance_rate; d.max_depth),
-        d.num_samples;
-        init_params=[d.p; ϵ0],
+        MCMCThreads(),
+        d.num_samples,
+        d.num_chains;
+        init_params=[d.p,ϵ0],
         progress=true,
         save_state=true,
         callback,
@@ -78,6 +80,9 @@ function parse_commandline_rbc_1_joint(args)
         arg_type = Vector{Float64}
         "--num_samples"
         help = "samples to draw in chain"
+        arg_type = Int64
+        "--num_chains"
+        help = "number of chains to sample"
         arg_type = Int64
         "--adapts_burnin_prop"
         help = "Proportion of Adaptations burned in"

--- a/src/estimate_rbc_1_kalman.jl
+++ b/src/estimate_rbc_1_kalman.jl
@@ -28,13 +28,15 @@ function estimate_rbc_1_kalman(d)
     num_adapts = convert(Int64, floor(d.num_samples * d.adapts_burnin_prop))
 
     Random.seed!(d.seed)
-    @info "Generating $(d.num_samples) samples with $(num_adapts) adapts"
+    @info "Generating $(d.num_samples) samples with $(num_adapts) adapts across $(d.num_chains) chains"
     alg = NUTS(num_adapts, d.target_acceptance_rate)
 
     chain = sample(
         turing_model,
         NUTS(num_adapts, d.target_acceptance_rate; d.max_depth),
-        d.num_samples;
+        MCMCThreads(),
+        d.num_samples,
+        d.num_chains;
         init_params=d.p,
         progress=true,
         save_state=true,
@@ -78,6 +80,9 @@ function parse_commandline_rbc_1_kalman(args)
         arg_type = Vector{Float64}
         "--num_samples"
         help = "samples to draw in chain"
+        arg_type = Int64
+        "--num_chains"
+        help = "number of chains to sample"
         arg_type = Int64
         "--adapts_burnin_prop"
         help = "Proportion of Adaptations burned in"

--- a/src/estimate_rbc_2_joint.jl
+++ b/src/estimate_rbc_2_joint.jl
@@ -28,14 +28,16 @@ function estimate_rbc_2_joint(d)
     num_adapts = convert(Int64, floor(d.num_samples * d.adapts_burnin_prop))
 
     Random.seed!(d.seed)
-    @info "Generating $(d.num_samples) samples with $(num_adapts) adapts"
+    @info "Generating $(d.num_samples) samples with $(num_adapts) adapts across $(d.num_chains) chains"
     alg = NUTS(num_adapts, d.target_acceptance_rate)
 
     chain = sample(
         turing_model,
         NUTS(num_adapts, d.target_acceptance_rate; d.max_depth),
-        d.num_samples;
-        init_params=[d.p; ϵ0],
+        MCMCThreads(),
+        d.num_samples,
+        d.num_chains;
+        init_params=[d.p,ϵ0],
         progress=true,
         save_state=true,
         callback,
@@ -78,6 +80,9 @@ function parse_commandline_rbc_2_joint(args)
         arg_type = Vector{Float64}
         "--num_samples"
         help = "samples to draw in chain"
+        arg_type = Int64
+        "--num_chains"
+        help = "number of chains to sample"
         arg_type = Int64
         "--adapts_burnin_prop"
         help = "Proportion of Adaptations burned in"

--- a/src/rbc_1_joint_defaults.txt
+++ b/src/rbc_1_joint_defaults.txt
@@ -13,3 +13,4 @@
 --print_level=0
 --epsilon_BK=1e-6
 --use_solution_cache=false
+--num_chains=4

--- a/src/rbc_1_kalman_defaults.txt
+++ b/src/rbc_1_kalman_defaults.txt
@@ -13,3 +13,4 @@
 --print_level=0
 --epsilon_BK=1e-6
 --use_solution_cache=false
+--num_chains=4

--- a/src/rbc_2_joint_defaults.txt
+++ b/src/rbc_2_joint_defaults.txt
@@ -13,3 +13,4 @@
 --print_level=0
 --epsilon_BK=1e-6
 --use_solution_cache=false
+--num_chains=4


### PR DESCRIPTION
Adds the keyword argument `--num_chains`, defaulted to 4, to all models.